### PR TITLE
feat: quietly handle <C-c>

### DIFF
--- a/lua/cling.lua
+++ b/lua/cling.lua
@@ -105,10 +105,8 @@ end
 -- Prompts for an environment file and sets it for the next command.
 function M.with_env()
     local ok, env_file =
-        pcall(vim.fn.input, "Path to .env file: ",
-            core.last_env or vim.fs.joinpath(vim.fn.getcwd(), ".env"), "file")
+        pcall(vim.fn.input, "Path to .env file: ", core.last_env or vim.fs.joinpath(vim.fn.getcwd(), ".env"), "file")
     if not ok or not env_file then
-        vim.notify("Cancelled", vim.log.levels.WARN)
         return
     end
     core.last_env = env_file
@@ -132,15 +130,13 @@ function M.on_cli_command(args)
     local fargs = args.fargs
     if #fargs == 0 then
         local ok, cmd = pcall(vim.fn.input, "Cling command: ", core.last_cmd or "")
-        if not ok or not cmd then
-            vim.notify("Cancelled", vim.log.levels.WARN)
+        if not ok or not cmd or cmd == "" then
             return
         end
 
         local default_cwd = core.last_cwd or vim.fn.getcwd()
         local ok, cwd = pcall(vim.fn.input, "CWD: ", default_cwd, "dir")
-        if not ok or not cwd then
-            vim.notify("Cancelled", vim.log.levels.WARN)
+        if not ok or not cwd or cwd == "" then
             return
         end
 

--- a/lua/cling.lua
+++ b/lua/cling.lua
@@ -130,15 +130,15 @@ end
 function M.on_cli_command(args)
     local fargs = args.fargs
     if #fargs == 0 then
-        local cmd = vim.fn.input("Cling command: ", core.last_cmd or "")
-        if cmd == nil or cmd == "" then
+        local ok, cmd = pcall(vim.fn.input, "Cling command: ", core.last_cmd or "")
+        if not ok or not cmd or cmd == "" then
             vim.notify("Cancelled", vim.log.levels.WARN)
             return
         end
 
         local default_cwd = core.last_cwd or vim.fn.getcwd()
-        local cwd = vim.fn.input("CWD: ", default_cwd, "dir")
-        if cwd == nil or cwd == "" then
+        local ok, cwd = pcall(vim.fn.input, "CWD: ", default_cwd, "dir")
+        if not ok or not cwd or cwd == "" then
             vim.notify("Cancelled", vim.log.levels.WARN)
             return
         end

--- a/lua/cling.lua
+++ b/lua/cling.lua
@@ -104,9 +104,10 @@ end
 ---
 -- Prompts for an environment file and sets it for the next command.
 function M.with_env()
-    local env_file =
-        vim.fn.input("Path to .env file: ", core.last_env or vim.fs.joinpath(vim.fn.getcwd(), ".env"), "file")
-    if env_file == nil or env_file == "" then
+    local ok, env_file =
+        pcall(vim.fn.input, "Path to .env file: ",
+            core.last_env or vim.fs.joinpath(vim.fn.getcwd(), ".env"), "file")
+    if not ok or not env_file then
         vim.notify("Cancelled", vim.log.levels.WARN)
         return
     end
@@ -131,14 +132,14 @@ function M.on_cli_command(args)
     local fargs = args.fargs
     if #fargs == 0 then
         local ok, cmd = pcall(vim.fn.input, "Cling command: ", core.last_cmd or "")
-        if not ok or not cmd or cmd == "" then
+        if not ok or not cmd then
             vim.notify("Cancelled", vim.log.levels.WARN)
             return
         end
 
         local default_cwd = core.last_cwd or vim.fn.getcwd()
         local ok, cwd = pcall(vim.fn.input, "CWD: ", default_cwd, "dir")
-        if not ok or not cwd or cwd == "" then
+        if not ok or not cwd then
             vim.notify("Cancelled", vim.log.levels.WARN)
             return
         end

--- a/tests/cling/cli_spec.lua
+++ b/tests/cling/cli_spec.lua
@@ -55,7 +55,6 @@ describe("cling cli", function()
 
         cling.on_cli_command { fargs = {} }
 
-        assert.stub(notify_stub).was_called_with("Cancelled", vim.log.levels.WARN)
         assert.stub(executor_stub).was_not_called()
     end)
 


### PR DESCRIPTION
In the current version when the user cancels Cling during a vim.fn.input call with <C-c> the plugin throws an exception and requires an additional key-press to close the prompt.

By wrapping the calls to vim.fn.input in pcall we can ensure that the exception is not propagated and we can handle it locally.